### PR TITLE
fix: change RegistrationDate type to string

### DIFF
--- a/PracticeGadgetShopApi/Controllers/CustomerController.cs
+++ b/PracticeGadgetShopApi/Controllers/CustomerController.cs
@@ -72,7 +72,7 @@ namespace PracticeGadgetShopApi.Controllers
                     customerDto.LastName = Convert.ToString(reader["LastName"].ToString());
                     customerDto.Email = Convert.ToString(reader["Email"].ToString());
                     customerDto.Phone = Convert.ToString(reader["Phone"].ToString());
-                    customerDto.RegistrationDate = Convert.ToDateTime(reader["RegistrationDate"]);
+                    customerDto.RegistrationDate = Convert.ToString(reader["RegistrationDate"]);
 
                     customerList.Add(customerDto);
                 }

--- a/PracticeGadgetShopApi/Models/CustomerDto.cs
+++ b/PracticeGadgetShopApi/Models/CustomerDto.cs
@@ -9,7 +9,7 @@
         public string LastName { get; set; }
         public string Email { get; set; }
         public string Phone { get; set; }
-        public DateTime RegistrationDate { get; set; }
+        public string RegistrationDate { get; set; }
 
         #endregion
     }

--- a/prac-gadget-shop/src/app/components/customer/customer.component.ts
+++ b/prac-gadget-shop/src/app/components/customer/customer.component.ts
@@ -12,9 +12,9 @@ import { DialogBoxComponent } from '../dialog-box/dialog-box.component';
 })
 export class CustomerComponent implements OnInit {
     httpClient = inject(HttpClient);
+    private modalService = inject(NgbModal);
     customerData: any;
     customerIdToDelete: number = 0;
-    private modalService = inject(NgbModal);
 
     openAddCustomerDialog() {
         this.modalService


### PR DESCRIPTION
This pull request includes changes to the `PracticeGadgetShopApi` and `prac-gadget-shop` projects to alter data types and fix dependency injection order. The changes are as follows:

Data type changes:

* [`PracticeGadgetShopApi/Controllers/CustomerController.cs`](diffhunk://#diff-133f799305842a79a1779497f950232ada2fececec2c612088375669c1e7a36eL75-R75): Changed the `RegistrationDate` field from `DateTime` to `string` when populating `customerDto`.
* [`PracticeGadgetShopApi/Models/CustomerDto.cs`](diffhunk://#diff-f0b13fc6ef2e0e6f24ebb3ae1c64cd607afbf61514666f1084d24818d71eb763L12-R12): Updated the `RegistrationDate` property type from `DateTime` to `string` in the `CustomerDto` class.
* Updated Database according to the changes made in backend.